### PR TITLE
Add authentication state management to show UI based on authentication state

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,16 +1,32 @@
-<script>
-  import { Route, Router } from "svelte-routing";
+<script lang="ts">
+  import { Route, Router, navigate } from "svelte-routing";
   import SignIn from "./pages/SignIn.svelte";
   import Debug from "./debug/Components.svelte";
+  import {
+    currentAuthenticationState,
+    isAuthenticationRequired,
+  } from "./authentication";
 
-  export let url = "";
+  let url = "";
 
-  //TODO Check if user is authenticated
-  //TODO if not authenticated route to sign in
-  //TOTO else just show the UI lol
+  //TODO Handle error in UI and log them
+  const isAuthenticated =
+    $currentAuthenticationState !== "Authenticating" &&
+    $currentAuthenticationState !== "Unauthenticated" &&
+    "name" in $currentAuthenticationState;
+
+  // If not authenticated and route requires authentication, require user to sign in
+  if (!isAuthenticated && isAuthenticationRequired(location.pathname)) {
+    navigate("/signin");
+  }
 </script>
 
-<Router {url}>
-  <Route path="signin" component={SignIn} />
-  <Route path="debug/components" component={Debug} />
-</Router>
+{#if $currentAuthenticationState === "Authenticating"}
+  <!-- TODO add proper authenticating UI -->
+  <p>Authenticating...</p>
+{:else}
+  <Router {url}>
+    <Route path="signin" component={SignIn} />
+    <Route path="debug/components" component={Debug} />
+  </Router>
+{/if}

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -1,0 +1,132 @@
+import { readable, type Subscriber } from "svelte/store";
+import HttpStatusCode from "./httpStatusCodes";
+
+//TODO figure out how to show sign in error (oops I forgot the sign in page might need to be server side rendered...)
+// Sign in is a simple HTML form post to the sign in endpoint. The server sets a cookie and the page refreshes.
+// The refresh causes the app to get the current authentication state again. We get the authentication state by
+// attempting to fetch the users data which we need to always do anyways. If we get a 401 Unauthenticated response
+// we show the sign in form mentioned before.
+// The sign out is also just a button in a form post to the sign out endpoint after which the app will start again.
+// We don't bother reading the cookie or interpreting its data which should be encrypted anyways.
+// The advantage of cookie authentication is that we don't have to do a lot of state management like validating a token.
+// It also enables us to put src urls to images that require authentication into img elements because the browser
+// automatically attaches the cookie which authorizes the request.
+
+type UnexpectedStatusCode = {
+  unexpectedStatusCode: number;
+};
+type ResponseDeserializationError = {
+  deserializationError: Error;
+};
+type AuthenticationError =
+  | ConnectionError
+  | UnexpectedStatusCode
+  | ResponseDeserializationError;
+type User = {
+  name: string;
+  // The url we can fetch the users avatar image from e.g. "/api/users/current/avatar"
+  // This url is expected to be in a format that can be put into an img src attribute
+  avatarSourceUrl: URL;
+};
+type Unauthenticated = "Unauthenticated";
+type AuthenticatedUser = User;
+type Authenticating = "Authenticating";
+type AuthenticationState =
+  | Authenticating
+  | AuthenticatedUser
+  | Unauthenticated
+  | AuthenticationError;
+
+type ConnectionError = {
+  connectionError: Error;
+};
+
+// type AuthenticationStateStore = Readable<AuthenticationState>;
+
+// Singleton since there can be only one authentication state. Might incorporate this into a general global "AppState" singleton later
+// let currentAuthenticationState:
+//   | Promise<AuthenticationStateStore>
+//   | NotInitialized;
+
+function start(set: Subscriber<Authenticating>) {
+  getAuthenticationState().then(set);
+}
+
+const currentAuthenticationState = readable<AuthenticationState>(
+  "Authenticating",
+  start
+);
+
+async function getAuthenticationState(): Promise<AuthenticationState> {
+  // Assume this is the current user introspection endpoint
+  // Assume it requires "is authenticated" authorization
+  const url = "/api/users/current";
+
+  // We check if we are authenticated by retrieving the current users data.
+  // If we get an unauthenticated error code the user is not authenticated and needs to sign in.
+  // The browser sets and sends the cookie for authentication to the server automatically if a cookie is set
+  // We can not make any assumptions about the cookie
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    console.error(
+      error,
+      "Could not get current user for authentication state. Please check if connection is working."
+    );
+
+    return { connectionError: error };
+  }
+
+  if (!response.ok) {
+    return { unexpectedStatusCode: response.status };
+  }
+
+  // This could be a one liner but we will add user data here later
+  //TODO add user data
+  if (response.status === HttpStatusCode.Unauthenticated)
+    return "Unauthenticated";
+
+  // Assume JSON has valid format 😬
+  try {
+    const user = (await response.json()) as User;
+    return user;
+  } catch (error) {
+    return { deserializationError: error };
+  }
+}
+
+// async function getCurrentAuthenticationStateInternal(): Promise<AuthenticationStateStore> {
+//   // Else the authentication state has not been initialized yet and we fetch the current
+//   const result = await getAuthenticationState();
+
+//   const store = readable<AuthenticationState>(result);
+//   return store;
+// }
+
+// async function getCurrentAuthenticationState(): Promise<AuthenticationStateStore> {
+//   // This would require a mutex normally but from what I can tell it isn't needed in JS-land?
+//   // The goal here is to not run multiple authentication requests when multiple components request
+//   // the current authentications state (maybe a better solution is to solve this through a store?)
+//   if (currentAuthenticationState === "NotInitialized")
+//     currentAuthenticationState = getCurrentAuthenticationStateInternal();
+
+//   return await currentAuthenticationState;
+// }
+
+const publicRoutes = new Set(["/debug/components"]);
+
+function isAuthenticationRequired(route: string) {
+  // I don't like writing this logic but I haven't found a router package handling authorized routes.
+  // I should probably contribute to one
+
+  // Assume all routes require "is authenticated" authorization and those that do not need to be explicitly added
+  // This avoids giving users access to authorized pages accidentally
+  // Authorization should be enforced on the server but this avoids a bad user experience by avoiding showing users
+  // UI that breaks when they are not authorized
+  // For now we just check for an one to one match. This doesn't handle dynamic url parts yet
+
+  const isPublic = publicRoutes.has(route);
+  return !isPublic;
+}
+export { isAuthenticationRequired, currentAuthenticationState };

--- a/src/httpStatusCodes.ts
+++ b/src/httpStatusCodes.ts
@@ -1,0 +1,5 @@
+const HttpStatusCode = {
+  Unauthenticated: 401,
+};
+
+export default HttpStatusCode;

--- a/src/pages/SignIn.svelte
+++ b/src/pages/SignIn.svelte
@@ -1,9 +1,11 @@
 <script>
   import Logo from "../Logo.svelte";
   import OutlinedInput from "../components/OutlinedInput.svelte";
-
 </script>
 
+<svelte:head>
+  <title>Sign In</title>
+</svelte:head>
 <div
   class="flex min-h-full items-center justify-center py-12 px-4 sm:px-6 lg:px-8"
 >
@@ -18,7 +20,7 @@
         Sign in to your account
       </h2>
     </header>
-    <form class="space-y-6 px-5" action={import.meta.env.VITE_BACKEND_URL + "/signIn"} method="POST">
+    <form class="space-y-6 px-5" action="/signIn" method="POST">
       <OutlinedInput
         id="username"
         name="username"


### PR DESCRIPTION
The code in this PR works with some assumptions on how the backend API might work later so it needs to be adjusted when the APIs are implemented but the grunt work for the authentication state management is done. I spend some time thinking about this.
This is also the groundwork to enable showing different UI based on authorization like roles later.

I wrote this in the comments but I think it's ok to repeat here to elaborate my thoughts:

Sign in is a simple HTML form post to the sign in endpoint. The server sets a cookie and the page refreshes.
The refresh causes the app to get the current authentication state again. We get the authentication state by attempting to fetch the users data which we need to always do anyways. If we get a 401 Unauthenticated response we show the sign in form mentioned before.
The sign out is also just a button in a form post to the sign out endpoint after which the app will start again.
We don't bother reading the cookie or interpreting its data which should be encrypted anyways.
The advantage of cookie authentication is that we don't have to do a lot of state management like validating a token.
It also enables us to put src urls to images that require authentication into img elements because the browser automatically attaches the cookie which authorizes the request.